### PR TITLE
Add dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/url2ref"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/url2ref-cli"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/url2ref-web"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates), which enables us to automatically update our `cargo` dependencies.
Current update schedule is weekly, but can be changed.