### PR TITLE
Fix the build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
     <strong>Automatic reference generation for web resources</strong>
   </p>
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) ![build](https://img.shields.io/github/actions/workflow/status/url2ref/url2ref/build_and_test.yml)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) ![CI](https://img.shields.io/github/actions/workflow/status/url2ref/url2ref/.github%2Fworkflows%2Fci.yml?label=CI)
+
 </div>
 
 ## Motivation


### PR DESCRIPTION
The build status badge has now been fixed. Furthermore, it now display our full CI routine instead of just the `build_and_run.sh` from `url2ref-web`. I am merging this directly onto `main` because it does not touch any code and is strictly related to presentation.

![CI](https://img.shields.io/github/actions/workflow/status/url2ref/url2ref/.github%2Fworkflows%2Fci.yml?label=CI)