### PR TITLE
Add support for Docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+target/
+Cargo.lock
+
+url2ref-web/static/css
+url2ref-web/static/icons
+url2ref-web/static/js
+url2ref-web/static/popper
+url2ref-web/static/scss
+url2ref-web/npm/node_modules
+url2ref-web/npm/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node
+
+WORKDIR /usr/app
+
+COPY . .
+
+WORKDIR /usr/app/url2ref-web/npm
+RUN ./build.sh
+
+FROM rust:1.76
+
+
+COPY --from=0 . .
+
+WORKDIR /usr/app
+
+RUN cargo install --path url2ref-web
+
+WORKDIR /usr/app/url2ref-web
+
+ENV ROCKET_ADDRESS=0.0.0.0
+EXPOSE 8000
+
+CMD [ "cargo", "run", "-r" ]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports: 
+      - 8000:8000


### PR DESCRIPTION
`url2ref-web` can now be containerized using Docker. This is primarily useful when deploying the application. There is also some potential for using it in the CI process, but this is left untested for now.